### PR TITLE
Fix reentrancy

### DIFF
--- a/contracts/ERC20Pods.sol
+++ b/contracts/ERC20Pods.sol
@@ -54,7 +54,7 @@ abstract contract ERC20Pods is ERC20, IERC20Pods, ReentrancyGuardExt {
 
     function podBalanceOf(address pod, address account) public nonReentrantView(_guard) view returns(uint256) {
         if (hasPod(account, pod)) {
-            return balanceOf(account);
+            return super.balanceOf(account);
         }
         return 0;
     }

--- a/contracts/libs/ReentrancyGuard.sol
+++ b/contracts/libs/ReentrancyGuard.sol
@@ -32,7 +32,6 @@ library ReentrancyGuardLib {
 
 contract ReentrancyGuardExt {
     using ReentrancyGuardLib for ReentrancyGuardLib.Data;
-    error AccessDenied();
 
     modifier nonReentrant(ReentrancyGuardLib.Data storage self) {
         self.enter();

--- a/contracts/libs/ReentrancyGuard.sol
+++ b/contracts/libs/ReentrancyGuard.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+library ReentrancyGuardLib {
+    error ReentrantCall();
+
+    uint256 private constant _NOT_ENTERED = 1;
+    uint256 private constant _ENTERED = 2;
+
+    struct Data {
+        uint256 _status;
+    }
+
+    function init(Data storage self) internal {
+        self._status = _NOT_ENTERED;
+    }
+
+    function enter(Data storage self) internal {
+        if (self._status == _ENTERED) revert ReentrantCall();
+        self._status = _ENTERED;
+    }
+
+    function exit(Data storage self) internal {
+        self._status = _NOT_ENTERED;
+    }
+
+    function check(Data storage self) internal view returns (bool) {
+        return self._status == _ENTERED;
+    }
+}
+
+contract ReentrancyGuardExt {
+    using ReentrancyGuardLib for ReentrancyGuardLib.Data;
+    error AccessDenied();
+
+    modifier nonReentrant(ReentrancyGuardLib.Data storage self) {
+        self.enter();
+        _;
+        self.exit();
+    }
+
+    modifier nonReentrantView(ReentrancyGuardLib.Data storage self) {
+        if (self.check()) revert ReentrancyGuardLib.ReentrantCall();
+        _;
+    }
+}

--- a/test/ERC20Pods.js
+++ b/test/ERC20Pods.js
@@ -45,7 +45,7 @@ describe('ERC20Pods', function () {
         await wrongPod.setReturnGasBomb(true);
         const tx = await erc20Pods.addPod(wrongPod.address);
         const receipt = await tx.wait();
-        expect(receipt.gasUsed).to.be.lt(272123); // 272123 with solidity instead of assembly
+        expect(receipt.gasUsed).to.be.lt(274168);
         expect(await erc20Pods.pods(wallet1.address)).to.have.deep.equals([wrongPod.address]);
     });
 });


### PR DESCRIPTION
Fix reentrancy by protecting podBalanceOf() and balanceOf() from access during updateBalances() loop